### PR TITLE
check for gl.xr before gl.vr

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -521,8 +521,8 @@ export const useCanvas = (props: UseCanvasProps): PointerEvents => {
       // Start render-loop, either via RAF or setAnimationLoop for VR
       if (!state.current.vr) {
         invalidate(state)
-      } else if ((gl.vr || (gl as any).xr) && gl.setAnimationLoop) {
-        ;(gl.vr || (gl as any).xr).enabled = true
+      } else if (((gl as any).xr || gl.vr) && gl.setAnimationLoop) {
+        ;((gl as any).xr || gl.vr).enabled = true
         gl.setAnimationLoop((t: number) => renderGl(state, t, 0, true))
       } else console.warn('the gl instance does not support VR!')
     }


### PR DESCRIPTION
avoids the warning “THREE.WebGLRenderer: .vr has been renamed to .xr”

see: https://github.com/mrdoob/three.js/blob/01579c3/src/Three.Legacy.js#L1742